### PR TITLE
Move profiles into root workspace, to fix remaining warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "lib",
     "binaries/server",
@@ -13,6 +14,24 @@ members = [
 [profile.release]
 opt-level = 2  # Maximum optimization level
 debug = true   # Includes debug information even in release builds
+
+[profile.release.package.voxelland]
+opt-level = 3       # Highest level of optimization
+# lto = true          # Enable Link Time Optimization
+# panic = 'abort'     # Abort on panic, which can reduce binary size and slightly increase performance
+# codegen-units = 1   # This may increase compilation time but can improve runtime performance
+
+[profile.release.package.voxelland-client]
+opt-level = 3  # Maximum optimization level
+# lto = true     # Enables Link Time Optimization
+debug = true   # Includes debug information even in release builds
+codegen-units = 1   # This may increase compilation time but can improve runtime performance
+
+[profile.release.package.voxelland-server]
+opt-level = 3       # Highest level of optimization
+# lto = true          # Enable Link Time Optimization
+# panic = 'abort'     # Abort on panic, which can reduce binary size and slightly increase performance
+codegen-units = 1   # This may increase compilation time but can improve runtime performance
 
 [profile.deploy]
 inherits = "release"

--- a/binaries/client/Cargo.toml
+++ b/binaries/client/Cargo.toml
@@ -18,9 +18,3 @@ steamworks = "0.11.0"
 glfw = "0.55.0"
 tracing-appender = "0.2.3"
 parking_lot = "0.12.3"
-
-[profile.release]
-opt-level = 3  # Maximum optimization level
-lto = true     # Enables Link Time Optimization
-debug = true   # Includes debug information even in release builds
-codegen-units = 1   # This may increase compilation time but can improve runtime performance

--- a/binaries/server/Cargo.toml
+++ b/binaries/server/Cargo.toml
@@ -26,10 +26,3 @@ bevy = "0.14.1"
 [dependencies.rusqlite]
 version = "0.31.0"
 features = ["bundled"]
-
-
-[profile.release]
-opt-level = 3       # Highest level of optimization
-lto = true          # Enable Link Time Optimization
-# panic = 'abort'     # Abort on panic, which can reduce binary size and slightly increase performance
-codegen-units = 1   # This may increase compilation time but can improve runtime performance

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -67,13 +67,3 @@ criterion = "0.5.1"
 [[bench]]
 name = "benches"
 harness = false
-
-[profile.release]
-opt-level = 3       # Highest level of optimization
-lto = true          # Enable Link Time Optimization
-# panic = 'abort'     # Abort on panic, which can reduce binary size and slightly increase performance
-# codegen-units = 1   # This may increase compilation time but can improve runtime performance
-
-
-
-


### PR DESCRIPTION
Commented out some lines that don't work in profile overloads.